### PR TITLE
- "vcd_security_tag" Module Release 1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.tfstate.*
 secrets.tfvars
 secrets.auto.tfvars
+terraform.tfvars
+terraform.auto.tfvars
 providers.tf
 
 # Crash log files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VCD Security Tag Terraform Module
 
-This Terraform module allows you to create Security Tags and associate them with Virtual Machines (VMs) in an existing VMware Cloud Director (VCD) Environment.  This module can be used to provsion new Security Tags into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
+This Terraform module allows you to create Security Tags and associate them with Virtual Machines (VMs) in an existing VMware Cloud Director (VCD) Environment.  This module can be used to provision new Security Tags into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
 
 ## Requirements
 
@@ -38,7 +38,7 @@ This is an example of a `main.tf` file that uses the VCD Security Tag Terraform 
 
 ```terraform
 module "vcd_security_tags" {
-  source            = "github.com/global-vmware/vcd_security_tag.git?ref=v1.1.0"
+  source            = "github.com/global-vmware/vcd_security_tag.git?ref=v1.1.1"
   
   vdc_org_name      = "<US1-VDC-ORG-NAME>"
 

--- a/main.tf
+++ b/main.tf
@@ -10,14 +10,14 @@ terraform {
 }
 
 data "vcd_vm" "vm" {
-  for_each = toset(flatten(values(var.security_tags)))
-
-  name = each.value
+  for_each  = toset(flatten(values(var.security_tags)))
+  org       = var.vdc_org_name
+  name      = each.value
 }
 
 resource "vcd_security_tag" "security_tags" {
-  for_each = var.security_tags
-
-  name   = each.key
-  vm_ids = [for vm_name in each.value : data.vcd_vm.vm[vm_name].id]
+  for_each  = var.security_tags
+  org       = var.vdc_org_name
+  name      = each.key
+  vm_ids    = [for vm_name in each.value : data.vcd_vm.vm[vm_name].id]
 }


### PR DESCRIPTION
- "vcd_security_tag" Module Release 1.1.1

- Added the "org" Argument to the "vcd_vm" Data Source

- Updated the source URL Reference in the "vcd_security_tag" Module Code Snippet to Version 1.1.1 in the Example Usage Section of the README